### PR TITLE
Reduce time for Upper_Minimizer function

### DIFF
--- a/pipelines/pipes_in_C/DMLimitsLib.C
+++ b/pipelines/pipes_in_C/DMLimitsLib.C
@@ -701,17 +701,6 @@ Number Upper_Minimizer(V &Kpars,
 		  }
 	      }
         }
-      
-      Number loglike = logL(x,0,nebins);
-      if (fabs(2*(maxlogL-loglike)) > 2.715 || fabs(2*(maxlogL-loglike)) < 2.705) 
-        {
-	  x=K_0;
-	  continue;
-        }
-      if (fabs(x[0]) > fabs(Upperlimit)) 
-        {
-	  Upperlimit = x[0]; Kpars = x;
-        }
     }
   
   Kpars = K_0;

--- a/pipelines/pipes_in_C/DMLimitsLib.C
+++ b/pipelines/pipes_in_C/DMLimitsLib.C
@@ -670,7 +670,26 @@ Number Upper_Minimizer(V &Kpars,
                 if (fabs(difflog)<=fabs(maxdiflog)) 
 		  {
                     maxdiflog = difflog;
-                    Kpars     = x;  
+                    Kpars     = x; 
+// ========================================================================== 
+                    Number loglike = logL(x,0,nebins);
+                    if (fabs(x[0]) > fabs(Upperlimit))
+                    {
+                        if (fabs(2*(maxlogL-loglike))>2.715 || 
+                            fabs(2*(maxlogL-loglike))<2.705)
+                        {
+                            continue;
+                        }
+                        if (fabs(x[0]) > fabs(Upperlimit)) 
+                        {
+                            Upperlimit = x[0]; 
+                            Kpars      = x;
+                            cout << "trial (within iter)= " << trial << "  " 
+                                 << Kpars[0] << "  " << Kpars[1] << endl;
+                            continue;
+                        }
+                    }
+// ========================================================================== 
 		  }
                 else if (j==0) 
 		  {


### PR DESCRIPTION
If x[0] > UpperLimit within iter for loop, continue.
Same performance as without this change, less running time.